### PR TITLE
Feat/remove agent name as bot check

### DIFF
--- a/src/Manager/Bridge.ts
+++ b/src/Manager/Bridge.ts
@@ -367,7 +367,7 @@ export class Bridge extends Server {
         this._debug(`Created shardClusterList: ${JSON.stringify(this.shardClusterList)}`);
 
         // Update Shard Data:
-        const clients = Array.from(this.clients.values()).filter(c => c.agent === 'bot');
+        const clients = Array.from(this.clients.values()).filter(c => c.bot);
         const message = {
             totalShards: this.totalShards,
             shardClusterList: this.shardClusterList,
@@ -401,7 +401,7 @@ export class Bridge extends Server {
         if (!options) options = { filter: undefined }
 
         const message = { script, options, _type: messageType.SERVER_BROADCAST_REQUEST };
-        const clients = Array.from(this.clients.values()).filter(options.filter || (c => c.agent === 'bot'));
+        const clients = Array.from(this.clients.values()).filter(options.filter || (c => c.bot));
         const promises = [];
         for (const client of clients) promises.push(client.request(message, options.timeout));
         return Promise.all(promises);


### PR DESCRIPTION
Made a change to not be stuck to the agent to check whether or not a connected client is a bot or not. 

Having to set the agent to bot for every instance felt counter-intuitive as the agent name could be something other than bot (in my use case it was at least) and this would break the connecting/disconnecting to the bridge.

With this boolean, you can say if it is a bot client or something else connecting while being able to have custom agent names. 